### PR TITLE
Don't split out message queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Version 0.55.92
+
+- Added ability not to split out message queues during shard split
+
 ## Version 0.55.91
 
 - Try to use old persistent states in cold boot if newest one is not ready yet

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 build = 'common/build/build.rs'
 edition = '2021'
 name = 'ton_node'
-version = '0.55.91'
+version = '0.55.92'
 
 [workspace]
 members = [ 'storage' ]

--- a/catchain/src/catchain.rs
+++ b/catchain/src/catchain.rs
@@ -613,7 +613,7 @@ impl ReceiverListener for ReceiverListenerImpl {
         //TODO: call processor directly instead of posting closure
         if CATCHAIN_POSTPONED_SEND_TO_OVERLAY {
             let overlay = Arc::downgrade(&self.overlay);
-            let receiver_ids: Vec<PublicKeyHash> = receiver_ids.into();
+            let receiver_ids = receiver_ids.to_vec();
             let sender_id = sender_id.clone();
             let message = message.clone();
 

--- a/src/tests/test_helper.rs
+++ b/src/tests/test_helper.rs
@@ -819,6 +819,20 @@ impl EngineOperations for TestEngine {
         self.now.load(Ordering::Relaxed)
     }
 
+    async fn find_mc_block_by_seq_no(&self, seqno: u32) -> Result<Arc<BlockHandle>> {
+        let mc_state = self.load_last_applied_mc_state().await?;
+        let mc_state_id = if mc_state.block_id().seq_no() == seqno {
+            mc_state.block_id().clone()
+        } else {
+            let (_, mc_state_id, _) = mc_state.shard_state_extra()?.prev_blocks.get(&seqno)?
+                .ok_or_else(|| error!("cannot find masterchain state seqno: {} last applied: {}", seqno, mc_state.block_id().seq_no()))?
+                .master_block_id();
+            mc_state_id
+        };
+        self.load_block_handle(&mc_state_id)?
+            .ok_or_else(|| error!("cannot load block handle for {} for masterchain state seqno {}", mc_state_id, seqno))
+    }
+
     fn load_block_handle(&self, id: &BlockIdExt) -> Result<Option<Arc<BlockHandle>>> {
         self.db.load_block_handle(id)
     }

--- a/src/types/limits.rs
+++ b/src/types/limits.rs
@@ -118,7 +118,7 @@ impl BlockLimitStatus {
         self.lt_current
     }
 
-    fn estimate_block_size(&self, extra: Option<&CellStorageStats>) -> u32 {
+    pub fn estimate_block_size(&self, extra: Option<&CellStorageStats>) -> u32 {
         let mut bits = 
             self.stats.cells_stats.bits + self.stats.proof_stats.bits;
         let mut cels = 

--- a/src/validating_utils.rs
+++ b/src/validating_utils.rs
@@ -45,6 +45,9 @@ pub fn supported_capabilities() -> u64 {
         GlobalCapabilities::CapSuspendedList as u64 |
         GlobalCapabilities::CapsTvmBugfixes2022 as u64 |
         GlobalCapabilities::CapTvmV19 as u64;
+        GlobalCapabilities::CapNoSplitOutQueue as u64 |
+        GlobalCapabilities::CapNoSplitOutQueue as u64 |
+        GlobalCapabilities::CapSuspendedList as u64;
     #[cfg(feature = "gosh")] 
     let caps = caps | GlobalCapabilities::CapDiff as u64;
     #[cfg(feature = "signature_with_id")] 

--- a/src/validating_utils.rs
+++ b/src/validating_utils.rs
@@ -1,5 +1,5 @@
 /*
-* Copyright (C) 2019-2021 TON Labs. All Rights Reserved.
+* Copyright (C) 2019-2024 EverX. All Rights Reserved.
 *
 * Licensed under the SOFTWARE EVALUATION License (the "License"); you may not use
 * this file except in compliance with the License.
@@ -54,7 +54,7 @@ pub fn supported_capabilities() -> u64 {
 }
 
 pub fn supported_version() -> u32 {
-    47
+    48
 }
 
 pub fn check_this_shard_mc_info(

--- a/src/validating_utils.rs
+++ b/src/validating_utils.rs
@@ -46,9 +46,6 @@ pub fn supported_capabilities() -> u64 {
         GlobalCapabilities::CapsTvmBugfixes2022 as u64 |
         GlobalCapabilities::CapNoSplitOutQueue as u64 |
         GlobalCapabilities::CapTvmV19 as u64;
-        GlobalCapabilities::CapNoSplitOutQueue as u64 |
-        GlobalCapabilities::CapNoSplitOutQueue as u64 |
-        GlobalCapabilities::CapSuspendedList as u64;
     #[cfg(feature = "gosh")] 
     let caps = caps | GlobalCapabilities::CapDiff as u64;
     #[cfg(feature = "signature_with_id")] 

--- a/src/validating_utils.rs
+++ b/src/validating_utils.rs
@@ -44,10 +44,8 @@ pub fn supported_capabilities() -> u64 {
         GlobalCapabilities::CapBounceAfterFailedAction as u64 |
         GlobalCapabilities::CapSuspendedList as u64 |
         GlobalCapabilities::CapsTvmBugfixes2022 as u64 |
+        GlobalCapabilities::CapNoSplitOutQueue as u64 |
         GlobalCapabilities::CapTvmV19 as u64;
-        GlobalCapabilities::CapNoSplitOutQueue as u64 |
-        GlobalCapabilities::CapNoSplitOutQueue as u64 |
-        GlobalCapabilities::CapSuspendedList as u64;
     #[cfg(feature = "gosh")] 
     let caps = caps | GlobalCapabilities::CapDiff as u64;
     #[cfg(feature = "signature_with_id")] 

--- a/src/validating_utils.rs
+++ b/src/validating_utils.rs
@@ -46,6 +46,9 @@ pub fn supported_capabilities() -> u64 {
         GlobalCapabilities::CapsTvmBugfixes2022 as u64 |
         GlobalCapabilities::CapNoSplitOutQueue as u64 |
         GlobalCapabilities::CapTvmV19 as u64;
+        GlobalCapabilities::CapNoSplitOutQueue as u64 |
+        GlobalCapabilities::CapNoSplitOutQueue as u64 |
+        GlobalCapabilities::CapSuspendedList as u64;
     #[cfg(feature = "gosh")] 
     let caps = caps | GlobalCapabilities::CapDiff as u64;
     #[cfg(feature = "signature_with_id")] 

--- a/src/validator/collator.rs
+++ b/src/validator/collator.rs
@@ -1801,6 +1801,7 @@ impl Collator {
         collator_data: &mut CollatorData
     ) -> Result<MsgQueueManager> {
         log::debug!("{}: request_neighbor_msg_queues", self.collated_block_descr);
+        let split_queues = !collator_data.config.has_capability(GlobalCapabilities::CapNoSplitOutQueue);
         MsgQueueManager::init(
             &self.engine,
             mc_data.state(),
@@ -2284,6 +2285,7 @@ impl Collator {
         exec_manager: &mut ExecutionManager,
     ) -> Result<()> {
         log::debug!("{}: process_inbound_internal_messages", self.collated_block_descr);
+        let split_queues = !collator_data.config.has_capability(GlobalCapabilities::CapNoSplitOutQueue);
         let mut iter = output_queue_manager.merge_out_queue_iter(&self.shard)?;
         while let Some(k_v) = iter.next() {
             let (key, enq, created_lt, block_id) = k_v?;

--- a/src/validator/collator.rs
+++ b/src/validator/collator.rs
@@ -1148,11 +1148,13 @@ impl Collator {
             0 => collator_data.block_limit_status.gas_used(),
             duration => collator_data.block_limit_status.gas_used() / duration
         };
+        let estimate_size = collator_data.block_limit_status.estimate_block_size(None);
 
         log::info!(
-            "{}: ASYNC COLLATED SIZE: {} GAS: {} TIME: {}ms GAS_RATE: {} TRANS: {}ms ID: {}",
+            "{}: ASYNC COLLATED SIZE: {} ESTIMATEED SiZE: {} GAS: {} TIME: {}ms GAS_RATE: {} TRANS: {}ms ID: {}",
             self.collated_block_descr,
             candidate.data.len(),
+            estimate_size,
             collator_data.block_limit_status.gas_used(),
             duration,
             ratio,
@@ -1801,7 +1803,6 @@ impl Collator {
         collator_data: &mut CollatorData
     ) -> Result<MsgQueueManager> {
         log::debug!("{}: request_neighbor_msg_queues", self.collated_block_descr);
-        let split_queues = !collator_data.config.has_capability(GlobalCapabilities::CapNoSplitOutQueue);
         MsgQueueManager::init(
             &self.engine,
             mc_data.state(),
@@ -2285,7 +2286,6 @@ impl Collator {
         exec_manager: &mut ExecutionManager,
     ) -> Result<()> {
         log::debug!("{}: process_inbound_internal_messages", self.collated_block_descr);
-        let split_queues = !collator_data.config.has_capability(GlobalCapabilities::CapNoSplitOutQueue);
         let mut iter = output_queue_manager.merge_out_queue_iter(&self.shard)?;
         while let Some(k_v) = iter.next() {
             let (key, enq, created_lt, block_id) = k_v?;

--- a/src/validator/out_msg_queue.rs
+++ b/src/validator/out_msg_queue.rs
@@ -323,7 +323,41 @@ impl OutMsgQueueInfoStuff {
         })
     }
 
-    fn merge(&mut self, other: &Self) -> Result<()> {
+    // checking or removing foreign messages from queue
+    // this operation should not be long because we don't allow
+    // to merge shards with long queues
+    fn clean_foreign_messages(&mut self, remove: bool) -> Result<bool> {
+        let shard = self.shard().clone();
+        let mut removed = false;
+        self.out_queue_mut()?.hashmap_filter(|_key, mut slice| {
+            let created_lt = u64::construct_from(&mut slice)?;
+            let enq = MsgEnqueueStuff::construct_from(&mut slice, created_lt)?;
+            if !shard.contains_full_prefix(enq.cur_prefix()) {
+                removed = true;
+                if remove {
+                    Ok(HashmapFilterResult::Cancel)
+                } else {
+                    Ok(HashmapFilterResult::Remove)
+                }
+            } else {
+                Ok(HashmapFilterResult::Accept)
+            }
+        })?;
+        Ok(removed)
+    }
+
+    fn merge(&mut self, mut other: Self, split_queues: bool, is_validate: bool) -> Result<()> {
+        if !split_queues {
+            if !is_validate {
+                // first we want to clean queues from foreign split messages
+                self.clean_foreign_messages(false)?;
+                other.clean_foreign_messages(false)?;
+            } else if self.clean_foreign_messages(true)? {
+                fail!("outbound queue for shard {} has messages from split", self.shard())
+            } else if other.clean_foreign_messages(true)? {
+                fail!("outbound queue for shard {} has messages from split", other.shard())
+            }
+        }
         let shard = self.shard().merge()?;
 
         self.out_queue_mut()?.combine_with(other.out_queue()?)?;
@@ -843,19 +877,14 @@ impl MsgQueueManager {
             neighbors.push(nb);
         }
 
-        let mut next_out_queue_info;
         let mut prev_out_queue_info = Self::load_out_queue_info(&prev_states[0], &last_mc_state, &mut cached_states, block_descr.clone()).await?;
         if prev_out_queue_info.block_id().seq_no != 0 {
             if let Some(state) = prev_states.get(1) {
                 CHECK!(after_merge);
                 let merge_out_queue_info = Self::load_out_queue_info(state, &last_mc_state, &mut cached_states, block_descr.clone()).await?;
                 log::debug!("{}: prepare merge for states {} and {}", block_descr, prev_out_queue_info.block_id(), merge_out_queue_info.block_id());
-                prev_out_queue_info.merge(&merge_out_queue_info)?;
+                prev_out_queue_info.merge(merge_out_queue_info, split_queues, next_state_opt.is_some())?;
                 Self::add_trivial_neighbor_after_merge(&mut neighbors, &shard, &prev_out_queue_info, prev_states, &stop_flag, block_descr.clone())?;
-                next_out_queue_info = match next_state_opt {
-                    Some(next_state) => Self::load_out_queue_info(next_state, &last_mc_state, &mut cached_states, block_descr.clone()).await?,
-                    None => prev_out_queue_info.clone()
-                };
             } else if after_split {
                 log::debug!("{}: prepare split for state {}", block_descr, prev_out_queue_info.block_id());
                 let own_usage_tree;
@@ -878,24 +907,15 @@ impl MsgQueueManager {
                 let sibling_out_queue_info = prev_out_queue_info.split(shard.clone(), engine, &usage_tree, imported_visited, split_queues)?;
                 Self::add_trivial_neighbor(&mut neighbors, &shard, &prev_out_queue_info, 
                     Some(sibling_out_queue_info), prev_states[0].shard(), &stop_flag, block_descr.clone())?;
-                next_out_queue_info = match next_state_opt {
-                    Some(next_state) => Self::load_out_queue_info(next_state, &last_mc_state, &mut cached_states, block_descr.clone()).await?,
-                    None => prev_out_queue_info.clone()
-                };
             } else {
                 Self::add_trivial_neighbor(&mut neighbors, &shard, &prev_out_queue_info, None, 
                     prev_out_queue_info.shard(), &stop_flag, block_descr.clone())?;
-                next_out_queue_info = match next_state_opt {
-                    Some(next_state) => Self::load_out_queue_info(next_state, &last_mc_state, &mut cached_states, block_descr.clone()).await?,
-                    None => prev_out_queue_info.clone()
-                };
             }
-        } else {
-            next_out_queue_info = match next_state_opt {
-                Some(next_state) => Self::load_out_queue_info(next_state, &last_mc_state, &mut cached_states, block_descr.clone()).await?,
-                None => prev_out_queue_info.clone()
-            };
         }
+        let mut next_out_queue_info = match next_state_opt {
+            Some(next_state) => Self::load_out_queue_info(next_state, &last_mc_state, &mut cached_states, block_descr.clone()).await?,
+            None => prev_out_queue_info.clone()
+        };
 
         // `ProcessedUptoStuff` seqno is a masterchain seqno for the old implementation
         let seqno = {
@@ -1135,7 +1155,7 @@ impl MsgQueueManager {
         clean_timeout_nanos: i128,
         optimistic_clean_percentage_points: u32,
         split_queues: bool,
-        mut on_message: impl FnMut(Option<MsgEnqueueStuff>, Option<u64>, Option<&Cell>) -> Result<bool>
+        mut on_message: impl FnMut(MsgEnqueueStuff, Option<u64>, Option<&Cell>) -> Result<bool>
     ) -> Result<(bool, i32, i32)> {
         let timer = std::time::Instant::now();
 
@@ -1157,6 +1177,7 @@ impl MsgQueueManager {
         let mut queue = self.next_out_queue_info.out_queue()?.clone();
         let mut deleted = 0;
         let mut skipped = 0;
+        let root = self.next_out_queue_info.out_queue()?.data();
 
         let ordered_cleaning_timeout_nanos = clean_timeout_nanos * (optimistic_clean_percentage_points as i128) / 1000;
         let random_cleaning_timeout_nanos = clean_timeout_nanos - ordered_cleaning_timeout_nanos;
@@ -1200,22 +1221,14 @@ impl MsgQueueManager {
                     let enq = MsgEnqueueStuff::construct_from(&mut data_and_refs, lt)?;
 
                     if !split_queues && !self.shard.contains_full_prefix(enq.cur_prefix()) {
-                        block_full = on_message(
-                            Some(enq),
-                            None,
-                            self.next_out_queue_info.out_queue()?.data(),
-                        )?;
+                        block_full = on_message(enq, None, root)?;
                         deleted += 1;
                         return Ok(HashmapFilterResult::Remove);
                     }
 
                     let (processed, end_lt) = self.already_processed(&enq)?;
                     if processed {
-                        block_full = on_message(
-                            Some(enq),
-                            Some(end_lt),
-                            self.next_out_queue_info.out_queue()?.data(),
-                        )?;
+                        block_full = on_message(enq, Some(end_lt), root)?;
                         deleted += 1;
                         return Ok(HashmapFilterResult::Remove);
                     }
@@ -1290,21 +1303,13 @@ impl MsgQueueManager {
                 let lt = u64::construct_from(&mut slice)?;
                 let enq = MsgEnqueueStuff::construct_from(&mut slice, lt)?;
                 if !split_queues && !self.shard.contains_full_prefix(enq.cur_prefix()) {
-                    block_full = on_message(
-                        Some(enq),
-                        None,
-                        self.next_out_queue_info.out_queue()?.data(),
-                    )?;
+                    block_full = on_message(enq, None, root)?;
                     deleted += 1;
                     return Ok(HashmapFilterResult::Remove);
                 }
                 let (processed, end_lt) = self.already_processed(&enq)?;
                 if processed {
-                    block_full = on_message(
-                        Some(enq),
-                        Some(end_lt),
-                        self.next_out_queue_info.out_queue()?.data()
-                    )?;
+                    block_full = on_message(enq, Some(end_lt), root)?;
                     random_deleted += 1;
                     return Ok(HashmapFilterResult::Remove)
                 }
@@ -1346,8 +1351,6 @@ impl MsgQueueManager {
         );
 
         self.next_out_queue_info.out_queue = Some(queue);
-
-        on_message(None, None, self.next_out_queue_info.out_queue()?.data())?;
 
         Ok((partial, deleted + skipped, deleted))
     }

--- a/src/validator/tests/test_collator.rs
+++ b/src/validator/tests/test_collator.rs
@@ -21,7 +21,7 @@ use crate::{
         validator_utils::compute_validator_set_cc,
     },
 };
-use ton_types::{error, Result};
+use ton_types::Result;
 use pretty_assertions::assert_eq;
 use std::sync::Arc;
 
@@ -72,10 +72,8 @@ async fn try_collate_by_engine(
     let min_mc_seq_no = if prev_blocks_ids[0].seq_no() == 0 {
         0
     } else {
-        let handle = engine.load_block_handle(&prev_blocks_ids[0])?.ok_or_else(
-            || error!("Cannot load handle for prev block {}", prev_blocks_ids[0])
-        )?;
-        engine.load_block(&handle).await?.block()?.read_info()?.min_ref_mc_seqno()
+        let state = engine.load_state(&prev_blocks_ids[0]).await?;
+        state.state()?.min_ref_mc_seqno()
     };
 
     let collator = collator::Collator::new(

--- a/src/validator/validate_query.rs
+++ b/src/validator/validate_query.rs
@@ -3761,8 +3761,7 @@ impl ValidateQuery {
                     and underload history (block cannot be both overloaded and underloaded)"
                 )
             }
-            if base.config_params.has_capability(GlobalCapabilities::CapNoSplitOutQueue) &&
-                next_state.underload_history() & 1 != 0 {
+            if base.split_queues && next_state.underload_history() & 1 != 0 {
                 Self::check_delivered_dequeued(&base, &manager)?;
             }
             if base.after_split || base.after_merge {


### PR DESCRIPTION
Outbound queues don't split during shard splitting. All outbound messages are copying to both states and will be cleaned up in next blocks. Additional checks added during execution inbound messages because now outbound queues contains not only messages for split shard. Underload flag could not be set for block if cleaning procedure was not made completely. So we will not get shards merging until they have foreign messages.